### PR TITLE
#3 チェックデジットが計算の過程で10になってしまう不具合の解消

### DIFF
--- a/src/calcJanCodeCheckDigit.test.ts
+++ b/src/calcJanCodeCheckDigit.test.ts
@@ -35,6 +35,7 @@ describe('calcJanCodeCheckDigit', () => {
       ['491009971074', '1'],
       ['351386327796', '2'],
       ['497163300200', '5'],
+      ['497163300205', '0'],
     ];
     for (const code of successCodeAndDigits) {
       test(code[0], () => {

--- a/src/calcJanCodeCheckDigit.ts
+++ b/src/calcJanCodeCheckDigit.ts
@@ -33,8 +33,15 @@ export const calcJanCodeCheckDigit = (codeWithoutDigit: string): string => {
   // 偶数桁の数値を加算したものを加算する
   const includeCheckDigitValue = sumEvenDigitArray + tripledOddDigitSum;
 
-  // 下一桁を10から減算したものがチェックデジット
-  return (10 - includeCheckDigitValue % 10).toString();
+  const lastDigit = includeCheckDigitValue % 10;
+  if (lastDigit === 0) {
+    // 下一桁が0となった場合は0がチェックデジット
+    return '0';
+  } else {
+    // 下一桁が0以外の場合、下一桁を10から減算したものがチェックデジット
+    return (10 - includeCheckDigitValue % 10).toString();
+  }
+
 }
 
 /**


### PR DESCRIPTION
# 内容
* 計算の過程で下一桁を求めるプロセスがあるが、その時に0になる場合のパターンが考慮漏れになっていた

# 参考
* https://www.dsri.jp/jan/check_digit.html